### PR TITLE
Add "trigger" to the accepted inputs

### DIFF
--- a/light-scheduler.html
+++ b/light-scheduler.html
@@ -330,6 +330,7 @@
         <li>off / 0 - Forces output to OFF state.</li>
         <li>light-only - Ignores the schedule and turns ON if it is considered dark.</li>
         <li>schedule-only - Ignores the light level and turns ON according to schedule.</li>
+        <li>trigger - Force output according to the ongoing settings.</li>
       </ul>
       <i>Please Note:</i> The override is runtime only and will revert to auto during deploy / restart.
       </p>

--- a/light-scheduler.js
+++ b/light-scheduler.js
@@ -108,7 +108,7 @@ module.exports = function(RED) {
 
     node.on('input', function(msg) {
       msg.payload = msg.payload.toString(); // Make sure we have a string.
-      if(msg.payload.match(/^(1|on|0|off|auto|stop|schedule-only|light-only)$/i))
+      if(msg.payload.match(/^(1|on|0|off|auto|stop|schedule-only|light-only|trigger)$/i))
       {
         if(msg.payload == '0') msg.payload = 'off';
         if(msg.payload == '1') msg.payload = 'on';


### PR DESCRIPTION
Adds **trigger** to the accepted inputs so that the output can be forced without showing _Failed to interpret incomming msg.payload. Ignoring it!_ as warn in the debug window.