### PR TITLE
Fix state change compare to cater for objects not references

### DIFF
--- a/light-scheduler.js
+++ b/light-scheduler.js
@@ -66,7 +66,7 @@ module.exports = function(RED) {
       node.status({fill: out?"green":"red", shape: "dot", text: (out ? 'ON' : 'OFF') + sunElevation + overrideTxt});
 
       // Only send anything if the state have changed.
-      if(node.outputfreq == 'output.minutely' || msg.payload !== node.prevPayload)
+      if(node.outputfreq == 'output.minutely' || !RED.util.compareObjects(msg.payload, node.prevPayload))
       {
         node.send(msg);
         node.prevPayload = msg.payload;


### PR DESCRIPTION
Hi Niklas,
Found an issue when using JSON on/off payloads with the comparison used to determine when to send a state change message. The compare was only comparing object references, not the content of the object. e.g. I use `{"on": true}` & `{"on": false}` as the on/off payloads.
Pull request uses a builtin node-red library function to compare the content.
Hope this can be included in the next release.

Thanks or a very useful node :-)