### PR TITLE
Create ability to use msg.override to send overrides

### DIFF
--- a/light-scheduler.html
+++ b/light-scheduler.html
@@ -341,9 +341,9 @@
   <p>For more information on planned features and changes please <a href="https://github.com/niklaswall/node-red-contrib-light-scheduler#planned-features--changes">read here</a>.</p>
   <h3>Inputs</h3>
   <dl class="message-properties">
-    <dt>payload <span class="property-type">string</span></dt>
+    <dt>override <span class="property-type">string</span></dt>
     <dd>
-      <p>The <code>msg.payload</code> will be used to set the override-mode of the light scheduler.</p>
+      <p>The <code>msg.override</code> will be used to set the override-mode of the light scheduler.</p>
       <p>Valid overrides:
       <ul>
         <li>auto - Removes the override and act according to configuration.</li>
@@ -354,7 +354,8 @@
         <li>schedule-only - Ignores the light level and turns ON according to schedule.</li>
         <li>trigger - Force output according to the ongoing settings.</li>
       </ul>
-      <i>Please Note:</i> The override is runtime only and will revert to auto during deploy / restart.
+      <i>Please Note:</i> The override is runtime only and will revert to auto during deploy / restart. <br/>
+      <i>Also Note:</i> the <code>msg.override</code> method replaces the former method of passing the override information in the payload of this message and the old method has now been deprecated and may be removed in subsequent versions.
       </p>
     </dd>
   </dl>

--- a/light-scheduler.js
+++ b/light-scheduler.js
@@ -113,17 +113,32 @@ module.exports = function(RED) {
     }
 
     node.on('input', function(msg) {
-      msg.payload = msg.payload.toString() // Make sure we have a string.
-      if (msg.payload.match(/^(1|on|0|off|auto|stop|schedule-only|light-only|trigger)$/i)) {
-        if (msg.payload == '0') msg.payload = 'off'
-        if (msg.payload == '1') msg.payload = 'on'
+      if !msg.override {
+        msg.payload = msg.payload.toString() // Make sure we have a string.
+        if (msg.payload.match(/^(1|on|0|off|auto|stop|schedule-only|light-only|trigger)$/i)) {
+          if (msg.payload == '0') msg.payload = 'off'
+          if (msg.payload == '1') msg.payload = 'on'
 
-        // Store override, unless trigger
-        if (!msg.payload.match(/^(trigger)$/i)) node.override = msg.payload.toLowerCase()
-        else node.manualTrigger = true
+          // Store override, unless trigger
+          if (!msg.payload.match(/^(trigger)$/i)) node.override = msg.payload.toLowerCase()
+          else node.manualTrigger = true
 
-        evaluate()
-      } else node.warn('Failed to interpret incoming msg.payload. Ignoring it!')
+          evaluate()
+        } else node.warn('Failed to interpret incoming msg.payload. Ignoring it!')
+      } else {
+        msg.override = msg.override.toString() // Make sure we have a string.
+        if (msg.override.match(/^(1|on|0|off|auto|stop|schedule-only|light-only|trigger)$/i)) {
+          if (msg.override == '0') msg.override = 'off'
+          if (msg.override == '1') msg.override = 'on'
+
+          // Store override, unless trigger
+          if (!msg.override.match(/^(trigger)$/i)) node.override = msg.override.toLowerCase()
+          else node.manualTrigger = true
+
+          evaluate()
+        } else node.warn('Failed to interpret incoming msg.override. Ignoring it!')
+      }
+
     })
 
     // re-evaluate every minute

--- a/light-scheduler.js
+++ b/light-scheduler.js
@@ -113,7 +113,7 @@ module.exports = function(RED) {
     }
 
     node.on('input', function(msg) {
-      if !msg.override {
+      if (!msg.override) {
         msg.payload = msg.payload.toString() // Make sure we have a string.
         if (msg.payload.match(/^(1|on|0|off|auto|stop|schedule-only|light-only|trigger)$/i)) {
           if (msg.payload == '0') msg.payload = 'off'


### PR DESCRIPTION
Hi there, this is my first PR on an open source project so please forgive me if my etiquette isn't quite right! :)

I have added the ability to pass the overrides in a msg.override rather than msg.payload (whlist still retaining msg.payload as an option for backwards compatibility).  I updated the HTML for the node to reflect the change and to warn that the old method was deprecated (looking at other conversations it sounded like that was the direction you might be going in).

I have tested this locally and it seems to do what I would expect - other than my change it seems to behave as usual.

I don't know if this would open up future opportunities to send an override alongside a supplemental payload (e.g. so you could pass a different payload to have a light switch on at a certain brightness) or to have a timed override (e.g. turn on a light that is scheduled off for a period specified in the payload).